### PR TITLE
cmake: remove redundant definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,18 +335,8 @@ set(OPENSSL_LIBS tls ssl crypto ${PLATFORM_LIBS})
 
 add_subdirectory(crypto)
 add_subdirectory(ssl)
-if(LIBRESSL_APPS)
-	add_subdirectory(apps)
-endif()
 add_subdirectory(tls)
 add_subdirectory(include)
-if(NOT MSVC)
-	add_subdirectory(man)
-endif()
-# Tests require the openssl executable and are unavailable when building shared libraries
-if(LIBRESSL_APPS AND LIBRESSL_TESTS)
-	add_subdirectory(tests)
-endif()
 
 if(NOT MSVC)
 	# Create pkgconfig files.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+Built from https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.2.tar.gz
+
+Modifications:
+- Removed tests/mandocs/pkgconfig/scripts/apps/cmake_uninstall from both filesystem and CMakeLists.txt
+- Removed m4 configuration files + make build scripts
+
+===
+
 ![LibreSSL image](https://www.libressl.org/images/libressl.jpg)
 ## Official portable version of [LibreSSL](https://www.libressl.org) ##
 


### PR DESCRIPTION
Remove redundant definitions to make it compile with Citra/Yuzu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/ext-libressl-portable/6)
<!-- Reviewable:end -->
